### PR TITLE
Pass query params

### DIFF
--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -334,6 +334,7 @@ class HttpxRequestAdapter(RequestAdapter):
             method=request_info.http_method.value,
             url=request_info.url,
             headers=request_info.request_headers,
+            params=request_info.query_parameters,
             content=request_info.content,
         )
         return request

--- a/tests/test_httpx_request_adapter.py
+++ b/tests/test_httpx_request_adapter.py
@@ -62,6 +62,15 @@ def test_get_request_from_request_information(request_adapter, request_info):
     assert isinstance(req, httpx.Request)
 
 
+# get_request_from_request_information should set query parameters on req
+def test_get_request_from_request_information_with_query_params(request_adapter, request_info):
+    request_info.http_method = Method.GET
+    request_info.url = BASE_URL
+    request_info.query_parameters = {"top": 100}
+    req = request_adapter.get_request_from_request_information(request_info)
+    assert isinstance(req, httpx.Request)
+    assert req.url.query == b'top=100'
+
 def test_enable_backing_store(request_adapter):
     request_adapter.enable_backing_store(None)
     assert request_adapter._parse_node_factory


### PR DESCRIPTION
This PR fixes a little problem I discovered trying to use the Kiota python generator -- the `get_request_from_request_information` method in `HttpxRequestAdapter` was not setting the query parameters in the returned request from the query parameters passed in the `request_info` passed by the caller.