### PR TITLE
Bugfix/request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed bug with middleware not respecting request options.
+
+## [0.3.0] - 2023-01-20
+
+### Changed
+
 - Enabled configuring of middleware during client creation by passing custom options in call to create with default middleware. [#56](https://github.com/microsoft/kiota-http-python/issues/56)
 
 ## [0.2.4] - 2023-01-17

--- a/kiota_http/_version.py
+++ b/kiota_http/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.3.0'
+VERSION: str = '0.3.1'

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -317,17 +317,12 @@ class HttpxRequestAdapter(RequestAdapter):
         await self._authentication_provider.authenticate_request(request_info)
 
         request = self.get_request_from_request_information(request_info)
-
-        # Pass request options in the headers as send method does not support.
-        # The header will be removed by the last middleware before the request is sent.
-        request.headers["request_options"] = str(request_info.request_options)
-
         resp = await self._http_client.send(request)
         return resp
 
     def get_response_handler(self, request_info: RequestInformation) -> Any:
         response_handler_option = request_info.request_options.get(
-            ResponseHandlerOption().get_key()
+            ResponseHandlerOption.get_key()
         )
         if response_handler_option:
             return response_handler_option.response_handler
@@ -345,4 +340,5 @@ class HttpxRequestAdapter(RequestAdapter):
             headers=request_info.request_headers,
             content=request_info.content,
         )
+        request.options = request_info.request_options
         return request

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -321,9 +321,7 @@ class HttpxRequestAdapter(RequestAdapter):
         return resp
 
     def get_response_handler(self, request_info: RequestInformation) -> Any:
-        response_handler_option = request_info.request_options.get(
-            ResponseHandlerOption.get_key()
-        )
+        response_handler_option = request_info.request_options.get(ResponseHandlerOption.get_key())
         if response_handler_option:
             return response_handler_option.response_handler
         return None
@@ -340,5 +338,5 @@ class HttpxRequestAdapter(RequestAdapter):
             headers=request_info.request_headers,
             content=request_info.content,
         )
-        request.options = request_info.request_options
+        request.options = request_info.request_options  # type:ignore
         return request

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -113,7 +113,7 @@ class HttpxRequestAdapter(RequestAdapter):
 
         response_handler = self.get_response_handler(request_info)
         if response_handler:
-            return await response_handler.handle_response_async(response)
+            return await response_handler.handle_response_async(response, error_map)
 
         await self.throw_failed_responses(response, error_map)
         if self._should_return_none(response):
@@ -143,7 +143,7 @@ class HttpxRequestAdapter(RequestAdapter):
 
         response_handler = self.get_response_handler(request_info)
         if response_handler:
-            return await response_handler.handle_response_async(response)
+            return await response_handler.handle_response_async(response, error_map)
 
         await self.throw_failed_responses(response, error_map)
         if self._should_return_none(response):
@@ -175,7 +175,7 @@ class HttpxRequestAdapter(RequestAdapter):
 
         response_handler = self.get_response_handler(request_info)
         if response_handler:
-            return await response_handler.handle_response_async(response)
+            return await response_handler.handle_response_async(response, error_map)
 
         await self.throw_failed_responses(response, error_map)
         if self._should_return_none(response):
@@ -206,7 +206,7 @@ class HttpxRequestAdapter(RequestAdapter):
 
         response_handler = self.get_response_handler(request_info)
         if response_handler:
-            return await response_handler.handle_response_async(response)
+            return await response_handler.handle_response_async(response, error_map)
 
         await self.throw_failed_responses(response, error_map)
         if self._should_return_none(response):
@@ -243,7 +243,7 @@ class HttpxRequestAdapter(RequestAdapter):
 
         response_handler = self.get_response_handler(request_info)
         if response_handler:
-            return await response_handler.handle_response_async(response)
+            return await response_handler.handle_response_async(response, error_map)
 
         await self.throw_failed_responses(response, error_map)
 

--- a/kiota_http/middleware/middleware.py
+++ b/kiota_http/middleware/middleware.py
@@ -48,9 +48,9 @@ class BaseMiddleware():
 
     async def send(self, request, transport):
         if self.next is None:
-            # Remove request options. No longer needed.
-            if 'request_options' in request.headers:
-                del request.headers['request_options']
+            # Remove request options if there's no other middleware in the chain.
+            if request.options:
+                delattr(request, 'options')
             response = await transport.handle_async_request(request)
             response.request = request
             return response

--- a/kiota_http/middleware/options/__init__.py
+++ b/kiota_http/middleware/options/__init__.py
@@ -2,4 +2,4 @@ from .parameters_name_decoding_handler_option import ParametersNameDecodingHandl
 from .redirect_handler_option import RedirectHandlerOption
 from .response_handler_option import ResponseHandlerOption
 from .retry_handler_option import RetryHandlerOption
-from .telemetry_handler_option import TelemetrytHandlerOption
+from .telemetry_handler_option import TelemetryHandlerOption

--- a/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
+++ b/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
@@ -43,5 +43,5 @@ class ParametersNameDecodingHandlerOption(RequestOption):
         self._characters_to_decode = value
 
     @staticmethod
-    def get_key(self) -> str:
-        return self.PARAMETERS_NAME_DECODING_HANDLER_OPTION_KEY
+    def get_key() -> str:
+        return ParametersNameDecodingHandlerOption.PARAMETERS_NAME_DECODING_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
+++ b/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
@@ -42,5 +42,6 @@ class ParametersNameDecodingHandlerOption(RequestOption):
     def characters_to_decode(self, value: List[str]):
         self._characters_to_decode = value
 
+    @staticmethod
     def get_key(self) -> str:
         return self.PARAMETERS_NAME_DECODING_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/redirect_handler_option.py
+++ b/kiota_http/middleware/options/redirect_handler_option.py
@@ -60,5 +60,6 @@ class RedirectHandlerOption(RequestOption):
     def allow_redirect_on_scheme_change(self, value: bool):
         self._allow_redirect_on_scheme_change = value
 
+    @staticmethod
     def get_key(self) -> str:
         return self.REDIRECT_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/redirect_handler_option.py
+++ b/kiota_http/middleware/options/redirect_handler_option.py
@@ -61,5 +61,5 @@ class RedirectHandlerOption(RequestOption):
         self._allow_redirect_on_scheme_change = value
 
     @staticmethod
-    def get_key(self) -> str:
-        return self.REDIRECT_HANDLER_OPTION_KEY
+    def get_key() -> str:
+        return RedirectHandlerOption.REDIRECT_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/response_handler_option.py
+++ b/kiota_http/middleware/options/response_handler_option.py
@@ -23,5 +23,5 @@ class ResponseHandlerOption(RequestOption):
         return self._response_handler
 
     @staticmethod
-    def get_key(self):
-        return self.RESPONSE_HANDLER_OPTION_KEY
+    def get_key():
+        return ResponseHandlerOption.RESPONSE_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/response_handler_option.py
+++ b/kiota_http/middleware/options/response_handler_option.py
@@ -22,5 +22,6 @@ class ResponseHandlerOption(RequestOption):
         """Property to return the response handler instance"""
         return self._response_handler
 
+    @staticmethod
     def get_key(self):
         return self.RESPONSE_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/retry_handler_option.py
+++ b/kiota_http/middleware/options/retry_handler_option.py
@@ -86,5 +86,6 @@ class RetryHandlerOption(RequestOption):
     def should_retry(self, value: bool) -> None:
         self._should_retry = value
 
+    @staticmethod
     def get_key(self):
         return self.RETRY_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/retry_handler_option.py
+++ b/kiota_http/middleware/options/retry_handler_option.py
@@ -87,5 +87,5 @@ class RetryHandlerOption(RequestOption):
         self._should_retry = value
 
     @staticmethod
-    def get_key(self):
-        return self.RETRY_HANDLER_OPTION_KEY
+    def get_key():
+        return RetryHandlerOption.RETRY_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/retry_handler_option.py
+++ b/kiota_http/middleware/options/retry_handler_option.py
@@ -14,10 +14,10 @@ class RetryHandlerOption(RequestOption):
     MAX_MAX_RETRIES: int = 10
 
     # Default delay value in seconds
-    DEFAULT_DELAY: int = 3
+    DEFAULT_DELAY: float = 3.0
 
     # Default maximum delay value in seconds
-    MAX_DELAY: int = 180
+    MAX_DELAY: float = 180.0
 
     # Default value for should retry
     DEFAULT_SHOULD_RETRY: bool = True
@@ -26,7 +26,7 @@ class RetryHandlerOption(RequestOption):
 
     def __init__(
         self,
-        delay: int = DEFAULT_DELAY,
+        delay: float = DEFAULT_DELAY,
         max_retries: int = DEFAULT_MAX_RETRIES,
         should_retry: bool = DEFAULT_SHOULD_RETRY
     ) -> None:
@@ -49,15 +49,15 @@ class RetryHandlerOption(RequestOption):
             raise ValueError(f'InvalidMinValue. MaxRetries should not be negative')
 
         self._max_retry: int = min(max_retries, self.MAX_MAX_RETRIES)
-        self._max_delay: int = min(delay, self.MAX_DELAY)
+        self._max_delay: float = min(delay, self.MAX_DELAY)
         self._should_retry: bool = should_retry
 
     @property
-    def max_delay(self) -> int:
+    def max_delay(self) -> float:
         return self._max_delay
 
     @max_delay.setter
-    def max_delay(self, value: int) -> None:
+    def max_delay(self, value: float) -> None:
         if value > self.MAX_DELAY:
             raise ValueError(f'MaxLimitExceeded. Delay should not be more than ${self.MAX_DELAY}')
         if value < 0:

--- a/kiota_http/middleware/options/telemetry_handler_option.py
+++ b/kiota_http/middleware/options/telemetry_handler_option.py
@@ -3,7 +3,7 @@ from typing import Callable
 from kiota_abstractions.request_option import RequestOption
 
 
-class TelemetrytHandlerOption(RequestOption):
+class TelemetryHandlerOption(RequestOption):
 
     TELEMETRY_HANDLER_OPTION_KEY = 'TelemetryHandlerOption'
 
@@ -19,5 +19,5 @@ class TelemetrytHandlerOption(RequestOption):
         self._telemetry_configurator = value
 
     @staticmethod
-    def get_key(self):
-        return self.TELEMETRY_HANDLER_OPTION_KEY
+    def get_key():
+        return TelemetryHandlerOption.TELEMETRY_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/options/telemetry_handler_option.py
+++ b/kiota_http/middleware/options/telemetry_handler_option.py
@@ -18,5 +18,6 @@ class TelemetrytHandlerOption(RequestOption):
     def telemetry_configurator(self, value: Callable[[], None]) -> None:
         self._telemetry_configurator = value
 
+    @staticmethod
     def get_key(self):
         return self.TELEMETRY_HANDLER_OPTION_KEY

--- a/kiota_http/middleware/parameters_name_decoding_handler.py
+++ b/kiota_http/middleware/parameters_name_decoding_handler.py
@@ -47,7 +47,7 @@ class ParametersNameDecodingHandler(BaseMiddleware):
         request.url = httpx.URL(updated_url)
         response = await super().send(request, transport)
         return response
-    
+
     def _get_current_options(self, request: httpx.Request) -> ParametersNameDecodingHandlerOption:
         """Returns the options to use for the request.Overries default options if
         request options are passed.
@@ -59,9 +59,11 @@ class ParametersNameDecodingHandler(BaseMiddleware):
             ParametersNameDecodingHandlerOption: The options to used.
         """
         current_options = self.options
-        request_options = request.options.get(ParametersNameDecodingHandlerOption.get_key())
+        request_options = request.options.get(              # type:ignore
+            ParametersNameDecodingHandlerOption.get_key()
+        )
         # Override default options with request options
         if request_options:
             current_options = request_options
-            
+
         return current_options

--- a/kiota_http/middleware/parameters_name_decoding_handler.py
+++ b/kiota_http/middleware/parameters_name_decoding_handler.py
@@ -30,19 +30,13 @@ class ParametersNameDecodingHandler(BaseMiddleware):
         """To execute the current middleware
 
         Args:
-            request (PreparedRequest): The prepared request object
-            request_options (Dict[str, RequestOption]): The request options
+            request (httpx.Request): The prepared request object
+            transport(httpx.AsyncBaseTransport): The HTTP transport to use
 
         Returns:
             Response: The response object.
         """
-        current_options = self.options
-        options_key = (
-            ParametersNameDecodingHandlerOption.PARAMETERS_NAME_DECODING_HANDLER_OPTION_KEY
-        )
-        request_options = json.loads(request.headers['request_options'])
-        if request_options and options_key in request_options:
-            current_options = request_options[options_key]
+        current_options = self._get_current_options(request)
 
         updated_url: str = str(request.url)  #type: ignore
         if (
@@ -53,3 +47,21 @@ class ParametersNameDecodingHandler(BaseMiddleware):
         request.url = httpx.URL(updated_url)
         response = await super().send(request, transport)
         return response
+    
+    def _get_current_options(self, request: httpx.Request) -> ParametersNameDecodingHandlerOption:
+        """Returns the options to use for the request.Overries default options if
+        request options are passed.
+
+        Args:
+            request (httpx.Request): The prepared request object
+
+        Returns:
+            ParametersNameDecodingHandlerOption: The options to used.
+        """
+        current_options = self.options
+        request_options = request.options.get(ParametersNameDecodingHandlerOption.get_key())
+        # Override default options with request options
+        if request_options:
+            current_options = request_options
+            
+        return current_options

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -59,7 +59,7 @@ class RedirectHandler(BaseMiddleware):
         the request if necessary.
         """
         current_options = self._get_current_options(request)
-            
+
         retryable = True
         while retryable:
             response = await super().send(request, transport)
@@ -87,13 +87,13 @@ class RedirectHandler(BaseMiddleware):
             RedirectHandlerOption: The options to used.
         """
         current_options = self.options
-        request_options = request.options.get(RedirectHandlerOption.get_key())
+        request_options = request.options.get(RedirectHandlerOption.get_key())  # type:ignore
         # Override default options with request options
         if request_options:
             current_options = request_options
-            
+
         return current_options
-    
+
     def _build_redirect_request(
         self, request: httpx.Request, response: httpx.Response
     ) -> httpx.Request:

--- a/kiota_http/middleware/retry_handler.py
+++ b/kiota_http/middleware/retry_handler.py
@@ -93,6 +93,8 @@ class RetryHandler(BaseMiddleware):
 
                     continue
             break
+        if response is None:
+            response = await super().send(request, transport)
         return response
 
     def _get_current_options(self, request: httpx.Request) -> RetryHandlerOption:

--- a/kiota_http/middleware/retry_handler.py
+++ b/kiota_http/middleware/retry_handler.py
@@ -95,6 +95,24 @@ class RetryHandler(BaseMiddleware):
             break
         return response
 
+    def _get_current_options(self, request: httpx.Request) -> RetryHandlerOption:
+        """Returns the options to use for the request.Overries default options if
+        request options are passed.
+
+        Args:
+            request (httpx.Request): The prepared request object
+
+        Returns:
+            RetryHandlerOption: The options to used.
+        """
+        current_options = self.options
+        request_options = request.options.get(RetryHandlerOption.get_key())  # type:ignore
+        # Override default options with request options
+        if request_options:
+            current_options = request_options
+
+        return current_options
+
     def should_retry(self, request, options, response):
         """
         Determines whether the request should be retried

--- a/tests/middleware_tests/test_redirect_handler.py
+++ b/tests/middleware_tests/test_redirect_handler.py
@@ -19,8 +19,8 @@ def test_no_config():
     """
     options = RedirectHandlerOption()
     handler = RedirectHandler()
-    assert handler.should_redirect == options.should_redirect
-    assert handler.max_redirects == options.max_redirect
+    assert handler.options.should_redirect == options.should_redirect
+    assert handler.options.max_redirect == options.max_redirect
     assert handler.redirect_on_status_codes == handler.DEFAULT_REDIRECT_STATUS_CODES
 
 
@@ -34,8 +34,8 @@ def test_custom_options():
 
     handler = RedirectHandler(options)
 
-    assert handler.max_redirects == 3
-    assert not handler.should_redirect
+    assert handler.options.max_redirect == 3
+    assert not handler.options.should_redirect
 
 
 def test_increment_redirects():
@@ -46,7 +46,7 @@ def test_increment_redirects():
     response = httpx.Response(301, request=request)
 
     handler = RedirectHandler()
-    assert handler.increment(response)
+    assert handler.increment(response, handler.options.max_redirect)
 
 
 def test_same_origin(mock_redirect_handler):

--- a/tests/middleware_tests/test_retry_handler.py
+++ b/tests/middleware_tests/test_retry_handler.py
@@ -57,7 +57,11 @@ def test_should_retry_valid():
     response = httpx.Response(503)
 
     retry_handler = RetryHandler()
-    assert retry_handler.should_retry(request, retry_handler.options, response,)
+    assert retry_handler.should_retry(
+        request,
+        retry_handler.options,
+        response,
+    )
 
 
 def test_should_retry_invalid():

--- a/tests/middleware_tests/test_retry_handler.py
+++ b/tests/middleware_tests/test_retry_handler.py
@@ -16,8 +16,8 @@ def test_no_config():
     """
     options = RetryHandlerOption()
     retry_handler = RetryHandler()
-    assert retry_handler.max_retries == options.max_retry
-    assert retry_handler.timeout == options.max_delay
+    assert retry_handler.options.max_retry == options.max_retry
+    assert retry_handler.options.max_delay == options.max_delay
     assert retry_handler.allowed_methods == frozenset(
         ['HEAD', 'GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
     )
@@ -35,9 +35,9 @@ def test_custom_options():
 
     retry_handler = RetryHandler(options)
 
-    assert retry_handler.max_retries == 1
-    assert retry_handler.timeout == 100
-    assert not retry_handler.retries_allowed
+    assert retry_handler.options.max_retry == 1
+    assert retry_handler.options.max_delay == 100
+    assert not retry_handler.options.should_retry
 
 
 def test_method_retryable_with_valid_method():
@@ -57,7 +57,7 @@ def test_should_retry_valid():
     response = httpx.Response(503)
 
     retry_handler = RetryHandler()
-    assert retry_handler.should_retry(request, response)
+    assert retry_handler.should_retry(request, retry_handler.options, response,)
 
 
 def test_should_retry_invalid():
@@ -69,7 +69,7 @@ def test_should_retry_invalid():
 
     retry_handler = RetryHandler()
 
-    assert not retry_handler.should_retry(request, response)
+    assert not retry_handler.should_retry(request, retry_handler.options, response)
 
 
 def test_is_request_payload_buffered_valid():
@@ -102,7 +102,7 @@ def test_check_retry_valid():
     """
     retry_handler = RetryHandler()
 
-    assert retry_handler.check_retry_valid(0)
+    assert retry_handler.check_retry_valid(0, retry_handler.options)
 
 
 def test_check_retry_valid_no_retries():
@@ -113,7 +113,7 @@ def test_check_retry_valid_no_retries():
     options.max_retry = 2
     retry_handler = RetryHandler(options)
 
-    assert not retry_handler.check_retry_valid(2)
+    assert not retry_handler.check_retry_valid(2, retry_handler.options)
 
 
 def test_get_retry_after():

--- a/tests/test_kiota_client_factory.py
+++ b/tests/test_kiota_client_factory.py
@@ -33,7 +33,7 @@ def test_create_with_default_middleware_options():
     assert isinstance(pipeline._first_middleware, RedirectHandler)
     retry_handler = pipeline._first_middleware.next
     assert isinstance(retry_handler, RetryHandler)
-    assert retry_handler.max_retries == retry_options.max_retry
+    assert retry_handler.options.max_retry == retry_options.max_retry
 
 
 def test_create_with_custom_middleware():
@@ -72,9 +72,9 @@ def test_get_default_middleware_with_options():
 
     assert len(middleware) == 3
     assert isinstance(middleware[0], RedirectHandler)
-    assert middleware[0].should_redirect is False
+    assert middleware[0].options.should_redirect is False
     assert isinstance(middleware[1], RetryHandler)
-    assert middleware[1].max_retries == 7
+    assert middleware[1].options.max_retry == 7
     assert isinstance(middleware[2], ParametersNameDecodingHandler)
 
 


### PR DESCRIPTION
## What this PR does

* Passes request options to request as attribute instead of headers
* Fixes bug with request options not overriding defaults
* Converts `get_key` method in request options to static method
* Fixes bugs in retry handler