### PR TITLE
Bugfix/primitive response deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-03-29
+
+### Added
+
+### Changed
+
+- Fixed bug with mapping when deserializing primitive response types.
+
 ## [0.4.0] - 2023-02-06
 
 ### Added

--- a/kiota_http/_version.py
+++ b/kiota_http/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.0'
+VERSION: str = '0.4.1'

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -212,18 +212,18 @@ class HttpxRequestAdapter(RequestAdapter):
         if self._should_return_none(response):
             return None
         root_node = await self.get_root_parse_node(response)
-        if response_type == str:
-            return root_node.get_string_value()
-        if response_type == int:
+        if response_type == "str":
+            return root_node.get_str_value()
+        if response_type == "int":
             return root_node.get_int_value()
-        if response_type == float:
+        if response_type == "float":
             return root_node.get_float_value()
-        if response_type == bool:
-            return root_node.get_boolean_value()
-        if response_type == datetime:
+        if response_type == "bool":
+            return root_node.get_bool_value()
+        if response_type == "datetime":
             return root_node.get_datetime_value()
-        if response_type == bytes:
-            return root_node.get_bytearray_value()
+        if response_type == "bytes":
+            return root_node.get_bytes_value()
         raise Exception("Found unexpected type to deserialize")
 
     async def send_no_response_content_async(

--- a/tests/test_httpx_request_adapter.py
+++ b/tests/test_httpx_request_adapter.py
@@ -192,7 +192,7 @@ async def test_send_primitive_async(
     request_adapter.get_root_parse_node = AsyncMock(return_value=mock_primitive)
     resp = await request_adapter.get_http_response_message(request_info)
     assert resp.headers.get("content-type") == 'application/json'
-    final_result = await request_adapter.send_primitive_async(request_info, float, {})
+    final_result = await request_adapter.send_primitive_async(request_info, "float", {})
     assert final_result == 22.3
 
 


### PR DESCRIPTION
Fixes `Exception: Found unexpected type to deserialize` errors due to incorrect type mappings when deserializing primitive response types.

fixes #https://github.com/microsoftgraph/msgraph-sdk-python/issues/118