### PR TITLE
Feature/backing store support

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -23,23 +23,22 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
-          pipenv install -r requirements-dev.txt
+          pip install -r requirements-dev.txt
       - name: Check code format
         run: |
-          pipenv run yapf -dr kiota_http
+          yapf -dr kiota_http
       - name: Check import order
         run: |
-          pipenv run isort kiota_http
+          isort kiota_http
       - name: Lint with Pylint
         run: |
-          pipenv run pylint kiota_http --disable=W --rcfile=.pylintrc
+          pylint kiota_http --disable=W --rcfile=.pylintrc
       - name: Static type checking with Mypy
         run: |
-          pipenv run mypy kiota_http
+          mypy kiota_http
       - name: Run tests with Pytest
         run: |
-          pipenv run pytest
+          pytest
 
   publish:
     name: Publish distribution to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.5] - 2023-07-18
+## [0.5.0] - 2023-07-27
 
 ### Added
 
 - Added a translator method to change a `RequestInformation` object into a HTTPX client request object.
+- Enabled backing store support
 
 ### Changed
 

--- a/kiota_http/_version.py
+++ b/kiota_http/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.5'
+VERSION: str = '0.5.0'

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -262,8 +262,8 @@ class HttpxRequestAdapter(RequestAdapter, Generic[ModelType]):
         )
         if not any([self._serialization_writer_factory, self._parse_node_factory]):
             raise Exception("Unable to enable backing store")
-        if backing_store_factory:
-            BackingStoreFactorySingleton.__instance = backing_store_factory
+        
+        BackingStoreFactorySingleton(backing_store_factory=backing_store_factory)
 
     async def get_root_parse_node(self, response: httpx.Response) -> ParseNode:
         payload = response.content

--- a/kiota_http/httpx_request_adapter.py
+++ b/kiota_http/httpx_request_adapter.py
@@ -262,7 +262,7 @@ class HttpxRequestAdapter(RequestAdapter, Generic[ModelType]):
         )
         if not any([self._serialization_writer_factory, self._parse_node_factory]):
             raise Exception("Unable to enable backing store")
-        
+
         BackingStoreFactorySingleton(backing_store_factory=backing_store_factory)
 
     async def get_root_parse_node(self, response: httpx.Response) -> ParseNode:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -88,7 +88,7 @@ httpx[http2]==0.24.1
 
 hyperframe==6.0.1
 
-microsoft-kiota-abstractions==0.6.0
+microsoft-kiota-abstractions==0.7.0
 
 sniffio==1.3.0
 


### PR DESCRIPTION
Enables backing store support for Python

Part of https://github.com/microsoft/kiota/issues/2858
Depends on https://github.com/microsoft/kiota-abstractions-python/pull/101

- [x] Instantiate `BackingStoreFactorySingleton` with the provided backing store factory