### PR TITLE
Chore/add opentelemetry dependency

### DIFF
--- a/kiota_http/_version.py
+++ b/kiota_http/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.6.0'
+VERSION: str = '0.6.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 dependencies = [
     "microsoft-kiota_abstractions >=0.4.0",
     "httpx[http2] >=0.23.0",
+    "opentelemetry-api >=1.20.0",
+    "opentelemetry-sdk >=1.20.0",
+    ""
 ]
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
Adds `opentelemetry` to required project dependencies.

Fixes #https://github.com/microsoftgraph/msgraph-sdk-python/issues/348

