### PR TITLE
Fix: handle relative redirects that have url.scheme == ''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2024-08-12
+
+### Added
+
+### Changed
+- Avoid raising an exception when a relative url is used as redirect location. 
+
 ## [1.3.2] - 2024-07-09
 
 ### Added

--- a/kiota_http/_version.py
+++ b/kiota_http/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.3.2'
+VERSION: str = '1.3.3'

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -174,7 +174,7 @@ class RedirectHandler(BaseMiddleware):
         except Exception as exc:
             raise Exception(f"Invalid URL in location header: {exc}.")
 
-        if not u.is_relative_url and url.scheme != request.url.scheme and not options.allow_redirect_on_scheme_change:
+        if not url.is_relative_url and url.scheme != request.url.scheme and not options.allow_redirect_on_scheme_change:
             raise Exception(
                 "Redirects with changing schemes not allowed by default.\
                 You can change this by modifying the allow_redirect_on_scheme_change\

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -174,7 +174,7 @@ class RedirectHandler(BaseMiddleware):
         except Exception as exc:
             raise Exception(f"Invalid URL in location header: {exc}.")
 
-        if url.scheme != request.url.scheme and not options.allow_redirect_on_scheme_change:
+        if not u.is_relative_url and url.scheme != request.url.scheme and not options.allow_redirect_on_scheme_change:
             raise Exception(
                 "Redirects with changing schemes not allowed by default.\
                 You can change this by modifying the allow_redirect_on_scheme_change\

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -174,7 +174,9 @@ class RedirectHandler(BaseMiddleware):
         except Exception as exc:
             raise Exception(f"Invalid URL in location header: {exc}.")
 
-        if not url.is_relative_url and url.scheme != request.url.scheme and not options.allow_redirect_on_scheme_change:
+        if (not url.is_relative_url 
+            and url.scheme != request.url.scheme 
+            and not options.allow_redirect_on_scheme_change):
             raise Exception(
                 "Redirects with changing schemes not allowed by default.\
                 You can change this by modifying the allow_redirect_on_scheme_change\

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -174,9 +174,10 @@ class RedirectHandler(BaseMiddleware):
         except Exception as exc:
             raise Exception(f"Invalid URL in location header: {exc}.")
 
-        if (not url.is_relative_url 
-            and url.scheme != request.url.scheme 
-            and not options.allow_redirect_on_scheme_change):
+        if (
+            not url.is_relative_url and url.scheme != request.url.scheme 
+            and not options.allow_redirect_on_scheme_change
+        ):
             raise Exception(
                 "Redirects with changing schemes not allowed by default.\
                 You can change this by modifying the allow_redirect_on_scheme_change\

--- a/kiota_http/middleware/redirect_handler.py
+++ b/kiota_http/middleware/redirect_handler.py
@@ -175,7 +175,7 @@ class RedirectHandler(BaseMiddleware):
             raise Exception(f"Invalid URL in location header: {exc}.")
 
         if (
-            not url.is_relative_url and url.scheme != request.url.scheme 
+            not url.is_relative_url and url.scheme != request.url.scheme
             and not options.allow_redirect_on_scheme_change
         ):
             raise Exception(


### PR DESCRIPTION
The raised error is a false positive: relative urls have scheme == '' which is different from http/https but still valid

## Overview

This PR fixes a bug with relative redirects (in my case from `http:localhost/something` to `/something/`) that raise an Exception.

## Related Issue

Fixes # (issue)

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output
